### PR TITLE
Refactor Home logic into use case

### DIFF
--- a/ListAI/Core/DI/DIContainer.swift
+++ b/ListAI/Core/DI/DIContainer.swift
@@ -14,6 +14,7 @@ final class DIContainer {
     let listUseCase: ListUseCaseProtocol
     let productUseCase: ProductUseCaseProtocol
     let iaUseCase: IAUseCaseProtocol
+    let shoppingListUseCase: ShoppingListUseCaseProtocol
     // puedes añadir los demás más adelante
     
     init(
@@ -28,12 +29,17 @@ final class DIContainer {
         self.productRepository = productRepository
         self.iaRepository = iaRepository
         // self.historialRepository = historialRepository
-        
+
         // Casos de uso
         self.authUseCase = AuthUseCase(repository: authRepository)
         self.listUseCase = ListUseCase(repository: listRepository)
         self.productUseCase = ProductUseCase(repository: productRepository)
         self.iaUseCase = IAUseCase(repository: iaRepository)
+        self.shoppingListUseCase = ShoppingListUseCase(
+            listUseCase: self.listUseCase,
+            productUseCase: self.productUseCase,
+            iaUseCase: self.iaUseCase
+        )
     }
 }
 

--- a/ListAI/Domain/UseCases/ShoppingListUseCase.swift
+++ b/ListAI/Domain/UseCases/ShoppingListUseCase.swift
@@ -1,0 +1,167 @@
+import Foundation
+import Combine
+
+protocol ShoppingListUseCaseProtocol {
+    func addProduct(name: String,
+                    to listID: String,
+                    existing: [ProductModel],
+                    addedByIA: Bool,
+                    dish: String?) -> AnyPublisher<Void, Error>
+
+    func toggleComprado(product: ProductModel, in listID: String) -> AnyPublisher<ProductModel, Error>
+
+    func editProduct(_ product: ProductModel,
+                     in listID: String,
+                     existing: [ProductModel]) -> AnyPublisher<ProductModel, Error>
+
+    func deleteProduct(_ productID: String, from listID: String) -> AnyPublisher<Void, Error>
+
+    func updateOrdenes(listID: String, products: [ProductModel]) -> AnyPublisher<Void, Error>
+
+    func fetchUniqueIngredients(for dish: String,
+                                context: IAContext,
+                                listName: String,
+                                existing: [ProductModel]) -> AnyPublisher<[String], Error>
+
+    func addIngredientsFromIA(for dish: String,
+                              list: ShoppingListModel,
+                              existing: [ProductModel]) -> AnyPublisher<Void, Error>
+
+    func analyzeList(_ list: ShoppingListModel,
+                     products: [ProductModel]) -> AnyPublisher<AnalysisResult, Error>
+}
+
+enum ShoppingListError: Error {
+    case duplicateItem
+    case emptyName
+}
+
+final class ShoppingListUseCase: ShoppingListUseCaseProtocol {
+    private let listUseCase: ListUseCaseProtocol
+    private let productUseCase: ProductUseCaseProtocol
+    private let iaUseCase: IAUseCaseProtocol
+
+    init(listUseCase: ListUseCaseProtocol,
+         productUseCase: ProductUseCaseProtocol,
+         iaUseCase: IAUseCaseProtocol) {
+        self.listUseCase = listUseCase
+        self.productUseCase = productUseCase
+        self.iaUseCase = iaUseCase
+    }
+
+    private func isDuplicate(_ name: String, existing: [ProductModel], excludingID: String? = nil) -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return existing.contains { product in
+            if let excludingID = excludingID, product.id == excludingID { return false }
+            return product.nombre.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == trimmed
+        }
+    }
+
+    func addProduct(name: String,
+                    to listID: String,
+                    existing: [ProductModel],
+                    addedByIA: Bool,
+                    dish: String?) -> AnyPublisher<Void, Error> {
+        let trimmed = name.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return Fail(error: ShoppingListError.emptyName).eraseToAnyPublisher() }
+        guard !isDuplicate(trimmed, existing: existing) else { return Fail(error: ShoppingListError.duplicateItem).eraseToAnyPublisher() }
+
+        let nextOrden = (existing.compactMap(\.orden).max() ?? -1) + 1
+        let product = ProductModel(id: UUID().uuidString,
+                                   orden: nextOrden,
+                                   nombre: trimmed,
+                                   esComprado: false,
+                                   añadidoPorIA: addedByIA,
+                                   ingredientesDe: dish)
+        return productUseCase.addProduct(listID: listID, product: product)
+    }
+
+    func toggleComprado(product: ProductModel, in listID: String) -> AnyPublisher<ProductModel, Error> {
+        var updated = product
+        updated.esComprado.toggle()
+        return productUseCase.updateProduct(listID: listID, product: updated)
+            .map { updated }
+            .eraseToAnyPublisher()
+    }
+
+    func editProduct(_ product: ProductModel,
+                     in listID: String,
+                     existing: [ProductModel]) -> AnyPublisher<ProductModel, Error> {
+        guard let id = product.id else { return Fail(error: ShoppingListError.emptyName).eraseToAnyPublisher() }
+        guard !isDuplicate(product.nombre, existing: existing, excludingID: id) else {
+            return Fail(error: ShoppingListError.duplicateItem).eraseToAnyPublisher()
+        }
+        return productUseCase.updateProduct(listID: listID, product: product)
+            .map { product }
+            .eraseToAnyPublisher()
+    }
+
+    func deleteProduct(_ productID: String, from listID: String) -> AnyPublisher<Void, Error> {
+        productUseCase.deleteProduct(listID: listID, productID: productID)
+    }
+
+    func updateOrdenes(listID: String, products: [ProductModel]) -> AnyPublisher<Void, Error> {
+        productUseCase.updateProductOrdenes(listID: listID, products: products)
+    }
+
+    func fetchUniqueIngredients(for dish: String,
+                                context: IAContext,
+                                listName: String,
+                                existing: [ProductModel]) -> AnyPublisher<[String], Error> {
+        iaUseCase.getIngredients(for: dish, context: context, listName: listName)
+            .map { ingredients in
+                ingredients.filter { !self.isDuplicate($0, existing: existing) }
+            }
+            .eraseToAnyPublisher()
+    }
+
+    func addIngredientsFromIA(for dish: String,
+                              list: ShoppingListModel,
+                              existing: [ProductModel]) -> AnyPublisher<Void, Error> {
+        iaUseCase.getIngredients(for: dish, context: list.context, listName: list.nombre)
+            .flatMap { [weak self] ingredients -> AnyPublisher<Void, Error> in
+                guard let self = self else { return Empty().eraseToAnyPublisher() }
+                let filtered = ingredients.filter { !self.isDuplicate($0, existing: existing) }
+                let publishers = filtered.enumerated().map { index, name in
+                    self.addProduct(name: name,
+                                    to: list.id ?? "",
+                                    existing: existing + filtered.prefix(index).map { element in
+                                        ProductModel(id: UUID().uuidString,
+                                                     orden: 0,
+                                                     nombre: element,
+                                                     esComprado: false,
+                                                     añadidoPorIA: true,
+                                                     ingredientesDe: dish)
+                                    },
+                                    addedByIA: true,
+                                    dish: dish)
+                }
+                return Publishers.MergeMany(publishers)
+                    .collect()
+                    .map { _ in () }
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+
+    func analyzeList(_ list: ShoppingListModel,
+                     products: [ProductModel]) -> AnyPublisher<AnalysisResult, Error> {
+        let pending = products.filter { !$0.esComprado }.map { $0.nombre }
+        let done = products.filter { $0.esComprado }.map { $0.nombre }
+        return iaUseCase.analyzeList(name: list.nombre,
+                                     context: list.context,
+                                     pending: pending,
+                                     done: done)
+            .map { [weak self] result in
+                guard let self = self else { return result }
+                let allNames = Set(products.map { $0.nombre.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() })
+                var filtered = result
+                filtered.suggestions = result.suggestions.filter {
+                    !allNames.contains($0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
+                }
+                return filtered
+            }
+            .eraseToAnyPublisher()
+    }
+}
+

--- a/ListAI/Presentation/Home/HomeViewModel.swift
+++ b/ListAI/Presentation/Home/HomeViewModel.swift
@@ -54,36 +54,22 @@ final class HomeViewModel: ObservableObject {
     
     private let listUseCase: ListUseCaseProtocol
     private let productUseCase: ProductUseCaseProtocol
-    private let iaUseCase: IAUseCaseProtocol
+    private let shoppingUseCase: ShoppingListUseCaseProtocol
     private let session: SessionManager
     private let authUseCase: AuthUseCaseProtocol
     private var cancellables = Set<AnyCancellable>()
-    private var nextOrden: Int {
-        (products.compactMap(\.orden).max() ?? -1) + 1
-    }
     
-    // MARK: - Duplicate detection
-    /// Devuelve `true` si `name` ya existe en `products`.
-    /// - Parameter excludingID: Si se pasa, ignora el producto con ese ID (útil para edición).
-    private func isDuplicate(_ name: String, excludingID: String? = nil) -> Bool {
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        return products.contains {
-            // Si se indica un ID a excluir, lo saltamos
-            if let excludingID = excludingID, $0.id == excludingID { return false }
-            return $0.nombre.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == trimmed
-        }
-    }
     
     // MARK: - Helpers
     
     init(listUseCase: ListUseCaseProtocol,
          productUseCase: ProductUseCaseProtocol,
-         iaUseCase: IAUseCaseProtocol,
+         shoppingUseCase: ShoppingListUseCaseProtocol,
          session: SessionManager,
          authUseCase: AuthUseCaseProtocol) {
         self.listUseCase = listUseCase
         self.productUseCase = productUseCase
-        self.iaUseCase = iaUseCase
+        self.shoppingUseCase = shoppingUseCase
         self.session = session
         self.authUseCase = authUseCase
         bindLists()
@@ -186,26 +172,21 @@ extension HomeViewModel {
 // MARK: - Product Management
 extension HomeViewModel {
     func addProductManually() {
-        guard let listID = activeList?.id,
-              !newProductName.trimmingCharacters(in: .whitespaces).isEmpty else {
-            return
-        }
-        let nextOrden = nextOrden
-
-        let newProduct = ProductModel(
-            id: UUID().uuidString,
-            orden: nextOrden,
-            nombre: newProductName.trimmingCharacters(in: .whitespaces),
-            esComprado: false,
-            añadidoPorIA: false,
-            ingredientesDe: nil
-        )
-
-        productUseCase.addProduct(listID: listID, product: newProduct)
+        guard let listID = activeList?.id else { return }
+        shoppingUseCase.addProduct(name: newProductName,
+                                   to: listID,
+                                   existing: products,
+                                   addedByIA: false,
+                                   dish: nil)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 if case let .failure(error) = completion {
-                    self?.errorMessage = error.localizedDescription
+                    if let listError = error as? ShoppingListError,
+                       listError == .duplicateItem {
+                        self?.manualDuplicateDetected = true
+                    } else {
+                        self?.errorMessage = error.localizedDescription
+                    }
                 }
             } receiveValue: { [weak self] in
                 self?.newProductName = ""
@@ -214,35 +195,23 @@ extension HomeViewModel {
     }
 
     func addProduct(named name: String) {
-        guard let listID = activeList?.id,
-              !name.trimmingCharacters(in: .whitespaces).isEmpty else {
-            return
-        }
-
-        if isDuplicate(name) {
-            manualDuplicateDetected = true
-            return
-        }
-
-        let nextOrden = nextOrden
-
-        let newProduct = ProductModel(
-            id: UUID().uuidString,
-            orden: nextOrden,
-            nombre: name.trimmingCharacters(in: .whitespaces),
-            esComprado: false,
-            añadidoPorIA: false,
-            ingredientesDe: nil
-        )
-
-        productUseCase.addProduct(listID: listID, product: newProduct)
+        guard let listID = activeList?.id else { return }
+        shoppingUseCase.addProduct(name: name,
+                                   to: listID,
+                                   existing: products,
+                                   addedByIA: false,
+                                   dish: nil)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 if case let .failure(error) = completion {
-                    self?.errorMessage = error.localizedDescription
+                    if let listError = error as? ShoppingListError,
+                       listError == .duplicateItem {
+                        self?.manualDuplicateDetected = true
+                    } else {
+                        self?.errorMessage = error.localizedDescription
+                    }
                 }
-            } receiveValue: { _ in
-            }
+            } receiveValue: { _ in }
             .store(in: &cancellables)
     }
 
@@ -252,17 +221,16 @@ extension HomeViewModel {
             return
         }
 
-        products[index].esComprado.toggle()
-        let updatedProduct = products[index]
-
-        // Actualiza el producto en la base de datos
-        productUseCase.updateProduct(listID: listID, product: updatedProduct)
+        let product = products[index]
+        shoppingUseCase.toggleComprado(product: product, in: listID)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 if case let .failure(error) = completion {
                     self?.errorMessage = error.localizedDescription
                 }
-            } receiveValue: { _ in }
+            } receiveValue: { [weak self] updated in
+                self?.products[index] = updated
+            }
             .store(in: &cancellables)
     }
 
@@ -270,7 +238,7 @@ extension HomeViewModel {
         guard let listID = activeList?.id,
               let productID = product.id else { return }
 
-        productUseCase.deleteProduct(listID: listID, productID: productID)
+        shoppingUseCase.deleteProduct(productID, from: listID)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 if case let .failure(error) = completion {
@@ -285,20 +253,20 @@ extension HomeViewModel {
     func editProduct(_ product: ProductModel) {
         guard let listID = activeList?.id else { return }
 
-        if isDuplicate(product.nombre, excludingID: product.id) {
-            editDuplicateDetected = true
-            return
-        }
-
-        productUseCase.updateProduct(listID: listID, product: product)
+        shoppingUseCase.editProduct(product, in: listID, existing: products)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 if case let .failure(error) = completion {
-                    self?.errorMessage = error.localizedDescription
+                    if let listError = error as? ShoppingListError,
+                       listError == .duplicateItem {
+                        self?.editDuplicateDetected = true
+                    } else {
+                        self?.errorMessage = error.localizedDescription
+                    }
                 }
-            } receiveValue: { [weak self] in
-                guard let index = self?.products.firstIndex(where: { $0.id == product.id }) else { return }
-                self?.products[index] = product
+            } receiveValue: { [weak self] updated in
+                guard let index = self?.products.firstIndex(where: { $0.id == updated.id }) else { return }
+                self?.products[index] = updated
                 self?.editingProduct = nil
             }
             .store(in: &cancellables)
@@ -313,30 +281,24 @@ extension HomeViewModel {
             products[index].orden = index
         }
 
-        productUseCase.updateProductOrdenes(listID: listID, products: products)
+        shoppingUseCase.updateOrdenes(listID: listID, products: products)
             .sink(receiveCompletion: { _ in }, receiveValue: { })
             .store(in: &cancellables)
     }
 
     func addIngredientManually(_ nombre: String, from plato: String) {
         guard let listID = activeList?.id else { return }
-
-        let product = ProductModel(
-            id: UUID().uuidString,
-            nombre: nombre,
-            esComprado: false,
-            añadidoPorIA: true,
-            ingredientesDe: plato
-        )
-
-        productUseCase.addProduct(listID: listID, product: product)
+        shoppingUseCase.addProduct(name: nombre,
+                                   to: listID,
+                                   existing: products,
+                                   addedByIA: true,
+                                   dish: plato)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 if case let .failure(error) = completion {
                     self?.errorMessage = error.localizedDescription
                 }
-            } receiveValue: { _ in
-            }
+            } receiveValue: { _ in }
             .store(in: &cancellables)
     }
 
@@ -355,40 +317,19 @@ extension HomeViewModel {
         iaErrorMessage = nil
 
         let dish = newProductName.trimmingCharacters(in: .whitespaces)
-
-        iaUseCase.getIngredients(for: dish, context: context, listName: activeList?.nombre ?? "")
+        guard let list = activeList else { return }
+        shoppingUseCase.addIngredientsFromIA(for: dish,
+                                             list: list,
+                                             existing: products)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 guard let self = self else { return }
                 self.isUsingIA = false
                 if case let .failure(error) = completion {
-                    self.iaErrorMessage = "Ocurrió un error al usar la IA: \(error.localizedDescription)"
+                    self.iaErrorMessage = error.localizedDescription
                 }
-            } receiveValue: { [weak self] ingredients in
-                guard let self = self else { return }
-                let baseOrden = self.nextOrden
-
-                let filtered = ingredients.filter { !self.isDuplicate($0) }
-                self.ignoredDuplicateNames = ingredients.filter { self.isDuplicate($0) }
-
-                let newProducts = filtered.enumerated().map { (index, ingredient) in
-                    ProductModel(
-                        id: UUID().uuidString,
-                        orden: baseOrden + index,
-                        nombre: ingredient,
-                        esComprado: false,
-                        añadidoPorIA: true,
-                        ingredientesDe: dish
-                    )
-                }
-
-                newProducts.forEach { product in
-                    self.productUseCase.addProduct(listID: listID, product: product)
-                        .sink(receiveCompletion: { _ in }, receiveValue: { })
-                        .store(in: &self.cancellables)
-                }
-
-                self.newProductName = ""
+            } receiveValue: { [weak self] in
+                self?.newProductName = ""
             }
             .store(in: &cancellables)
     }
@@ -403,35 +344,28 @@ extension HomeViewModel {
             return
         }
 
-        iaUseCase.getIngredients(for: dish, context: context, listName: listName)
+        shoppingUseCase.fetchUniqueIngredients(for: dish,
+                                               context: context,
+                                               listName: listName,
+                                               existing: products)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completionResult in
-                if case .failure(_) = completionResult {
-                    self?.iaErrorMessage = "Ocurrió un error al usar la IA"
+                if case let .failure(error) = completionResult {
+                    self?.iaErrorMessage = error.localizedDescription
                     self?.isUsingIA = false
                     completion([])
                 }
-            } receiveValue: { [weak self] ingredientes in
-                guard let self = self else {
-                    completion([])
-                    return
-                }
-                let nuevos = ingredientes.filter { !self.isDuplicate($0) }
-                completion(nuevos)
+            } receiveValue: { ingredientes in
+                completion(ingredientes)
             }
             .store(in: &cancellables)
     }
 
     func analyzeActiveList() {
         guard let list = activeList else { return }
-        let pending = products.filter { !$0.esComprado }.map { $0.nombre }
-        let done = products.filter { $0.esComprado }.map { $0.nombre }
-
         isAnalyzing = true
-        iaUseCase.analyzeList(name: list.nombre,
-                              context: list.context,
-                              pending: pending,
-                              done: done)
+        shoppingUseCase.analyzeList(list,
+                                    products: products)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] completion in
                 self?.isAnalyzing = false
@@ -439,15 +373,7 @@ extension HomeViewModel {
                     self?.iaErrorMessage = error.localizedDescription
                 }
             } receiveValue: { [weak self] result in
-                guard let self = self else { return }
-                // Filter out suggestions that are already present in either pending or done
-                let allNames = Set(self.products.map { $0.nombre.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() })
-                let filteredSuggestions = result.suggestions.filter {
-                    !allNames.contains($0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased())
-                }
-                var filteredResult = result
-                filteredResult.suggestions = filteredSuggestions
-                self.analysis = filteredResult
+                self?.analysis = result
             }
             .store(in: &cancellables)
     }

--- a/ListAI/Presentation/RootView.swift
+++ b/ListAI/Presentation/RootView.swift
@@ -15,7 +15,7 @@ struct RootView: View {
                         .environmentObject(HomeViewModel(
                             listUseCase: di.listUseCase,
                             productUseCase: di.productUseCase,
-                            iaUseCase: di.iaUseCase,
+                            shoppingUseCase: di.shoppingListUseCase,
                             session: session,
                             authUseCase: di.authUseCase
                         ))


### PR DESCRIPTION
## Summary
- delegate product and IA operations from `HomeViewModel` to a new `ShoppingListUseCase`
- expose the new use case via `DIContainer`
- update `RootView` to create `HomeViewModel` with the new dependency
- clean up `HomeViewModel` implementation

## Testing
- `swift --version`
- `swift build -c release` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6843bb140bdc832a880f7454d0cf1233