### PR TITLE
Hide FABs on scroll

### DIFF
--- a/ListAI/Presentation/Home/HomeView.swift
+++ b/ListAI/Presentation/Home/HomeView.swift
@@ -17,6 +17,7 @@ struct HomeView: View {
     @State private var isFetchingIngredients = false
     @State private var selectedProductID: String? = nil
     @State private var fabRotation: Double = 0
+    @State private var hideFloatingButtons = false
 
     // Floating action buttons for HomeView
     private var floatingButtons: some View {
@@ -79,7 +80,8 @@ struct HomeView: View {
                                 selectedProductID: $selectedProductID,
                                 showDeleteProductAlert: $showDeleteProductAlert,
                                 showDeleteListAlert: $showDeleteListAlert,
-                                editedName: $editedName
+                                editedName: $editedName,
+                                hideFloatingButtons: $hideFloatingButtons
                             )
                             .transition(.opacity.combined(with: .scale(scale: 0.95)))
                         }
@@ -94,7 +96,10 @@ struct HomeView: View {
                         IAThinkingOverlay()
                             .transition(.asymmetric(insertion: .scale.combined(with: .opacity), removal: .opacity))
                     }
-                    floatingButtons
+                    if !hideFloatingButtons {
+                        floatingButtons
+                            .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
                 }
             }
             .sheet(isPresented: $showAddProductSheet) {

--- a/ListAI/Presentation/Home/SubViews/ProductListView.swift
+++ b/ListAI/Presentation/Home/SubViews/ProductListView.swift
@@ -7,6 +7,9 @@ struct ProductListView: View {
     @Binding var showDeleteProductAlert: Bool
     @Binding var showDeleteListAlert: Bool
     @Binding var editedName: String
+    @Binding var hideFloatingButtons: Bool
+
+    @State private var lastScrollOffset: CGFloat = 0
     
     @State private var showDeleteSelectedAlert = false
 
@@ -121,6 +124,13 @@ struct ProductListView: View {
                         Spacer()
                     } else {
                         List {
+                            GeometryReader { proxy in
+                                Color.clear
+                                    .preference(key: ScrollOffsetPreferenceKey.self,
+                                                value: proxy.frame(in: .named("ProductListScroll")).minY)
+                            }
+                            .frame(height: 0)
+
                             ForEach(viewModel.products) { product in
                                 ProductRowView(
                                     product: product,
@@ -134,6 +144,16 @@ struct ProductListView: View {
                             }
                         }
                         .listStyle(.plain)
+                        .coordinateSpace(name: "ProductListScroll")
+                        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+                            let delta = value - lastScrollOffset
+                            if delta < -5 {
+                                withAnimation { hideFloatingButtons = true }
+                            } else if delta > 5 {
+                                withAnimation { hideFloatingButtons = false }
+                            }
+                            lastScrollOffset = value
+                        }
                         .padding(.top, 8)
                         .padding(.bottom, 4)
                         .animation(.spring(response: 0.4, dampingFraction: 0.75), value: viewModel.products)

--- a/ListAI/Presentation/Home/SubViews/ScrollOffsetPreferenceKey.swift
+++ b/ListAI/Presentation/Home/SubViews/ScrollOffsetPreferenceKey.swift
@@ -1,0 +1,8 @@
+import SwiftUI
+
+struct ScrollOffsetPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}


### PR DESCRIPTION
## Summary
- hide floating action buttons when scrolling product list
- show buttons again when scrolling upwards

## Testing
- `swift --version`

------
https://chatgpt.com/codex/tasks/task_e_684452a87a04832a8939086ca01c9a12